### PR TITLE
Fix invalid version specifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.7<3.9
+python_requires = >=3.7,<3.9
 install_requires = 
 	bcml~=3.8.0
 	pythonnet @ git+https://github.com/pythonnet/pythonnet


### PR DESCRIPTION
Resolves the following error when running `python install -e .`

```
setuptools.extern.packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=3.7<3.9'
```