### PR TITLE
Resolve conflicting dependency version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,8 @@ packages = find:
 include_package_data = True
 python_requires = >=3.7<3.9
 install_requires = 
-	bcml~=3.8.0
-	pythonnet @ git+https://github.com/pythonnet/pythonnet
+	bcml>=3.8.0
+	pythonnet>=3.0.0a2
 
 [options.entry_points]
 console_scripts = 


### PR DESCRIPTION
Update to match dependencies defined in `requirements.txt`:

```
bcml>=3.8.0
pythonnet>=3.0.0a2
```

Resolves #22 